### PR TITLE
Add dice folder with individual animations

### DIFF
--- a/components/dice/D100.tsx
+++ b/components/dice/D100.tsx
@@ -1,0 +1,15 @@
+'use client'
+import { FC } from 'react'
+import PopupResult from '../PopupResult'
+
+interface Props {
+  show: boolean
+  result: number | null
+  onFinish?: () => void
+}
+
+const D100: FC<Props> = ({ show, result, onFinish }) => (
+  <PopupResult show={show} result={result} diceType={100} onFinish={onFinish} />
+)
+
+export default D100

--- a/components/dice/D20.tsx
+++ b/components/dice/D20.tsx
@@ -1,0 +1,15 @@
+'use client'
+import { FC } from 'react'
+import PopupResult from '../PopupResult'
+
+interface Props {
+  show: boolean
+  result: number | null
+  onFinish?: () => void
+}
+
+const D20: FC<Props> = ({ show, result, onFinish }) => (
+  <PopupResult show={show} result={result} diceType={20} onFinish={onFinish} />
+)
+
+export default D20

--- a/components/dice/D4.tsx
+++ b/components/dice/D4.tsx
@@ -1,0 +1,15 @@
+'use client'
+import { FC } from 'react'
+import PopupResult from '../PopupResult'
+
+interface Props {
+  show: boolean
+  result: number | null
+  onFinish?: () => void
+}
+
+const D4: FC<Props> = ({ show, result, onFinish }) => (
+  <PopupResult show={show} result={result} diceType={4} onFinish={onFinish} />
+)
+
+export default D4

--- a/components/dice/D6.tsx
+++ b/components/dice/D6.tsx
@@ -1,0 +1,15 @@
+'use client'
+import { FC } from 'react'
+import PopupResult from '../PopupResult'
+
+interface Props {
+  show: boolean
+  result: number | null
+  onFinish?: () => void
+}
+
+const D6: FC<Props> = ({ show, result, onFinish }) => (
+  <PopupResult show={show} result={result} diceType={6} onFinish={onFinish} />
+)
+
+export default D6

--- a/components/dice/D8.tsx
+++ b/components/dice/D8.tsx
@@ -1,0 +1,15 @@
+'use client'
+import { FC } from 'react'
+import PopupResult from '../PopupResult'
+
+interface Props {
+  show: boolean
+  result: number | null
+  onFinish?: () => void
+}
+
+const D8: FC<Props> = ({ show, result, onFinish }) => (
+  <PopupResult show={show} result={result} diceType={8} onFinish={onFinish} />
+)
+
+export default D8

--- a/components/dice/index.ts
+++ b/components/dice/index.ts
@@ -1,0 +1,5 @@
+export { default as D4 } from './D4'
+export { default as D6 } from './D6'
+export { default as D8 } from './D8'
+export { default as D20 } from './D20'
+export { default as D100 } from './D100'


### PR DESCRIPTION
## Summary
- create `components/dice` folder
- add D4, D6, D8, D20 and D100 components that reuse the existing `PopupResult` animation
- export all dice components via a new index file

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687b919cbee4832d89ebbd93e709e914