### PR TITLE
Add basic dice icon assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,7 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Dice Assets
+
+Basic SVG shapes for dice animations are available in `public/dice`. These icons can be combined with custom animations to display D4, D6, D8, D20 and D100 visuals.

--- a/public/dice/D100.svg
+++ b/public/dice/D100.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="40" fill="#eee" stroke="#555" stroke-width="4" />
+  <text x="50" y="65" font-size="28" text-anchor="middle" fill="#333">100</text>
+</svg>

--- a/public/dice/D20.svg
+++ b/public/dice/D20.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="40" fill="#eee" stroke="#555" stroke-width="4" />
+  <text x="50" y="65" font-size="32" text-anchor="middle" fill="#333">20</text>
+</svg>

--- a/public/dice/D4.svg
+++ b/public/dice/D4.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <polygon points="50,10 90,90 10,90" fill="#eee" stroke="#555" stroke-width="4"/>
+  <text x="50" y="65" font-size="36" text-anchor="middle" fill="#333">4</text>
+</svg>

--- a/public/dice/D6.svg
+++ b/public/dice/D6.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="10" y="10" width="80" height="80" fill="#eee" stroke="#555" stroke-width="4"/>
+  <text x="50" y="65" font-size="36" text-anchor="middle" fill="#333">6</text>
+</svg>

--- a/public/dice/D8.svg
+++ b/public/dice/D8.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <polygon points="50,10 80,20 90,50 80,80 50,90 20,80 10,50 20,20" fill="#eee" stroke="#555" stroke-width="4"/>
+  <text x="50" y="65" font-size="36" text-anchor="middle" fill="#333">8</text>
+</svg>

--- a/public/dice/README.md
+++ b/public/dice/README.md
@@ -1,0 +1,1 @@
+These SVG files provide basic shapes for the available dice types. They are kept simple so they can be used with custom CSS animations.


### PR DESCRIPTION
## Summary
- add simple SVG icons for various dice in `public/dice`
- document the new dice assets in README

## Testing
- `npm run build` *(fails: failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_687b9874b70c832dbb2049b26a53e275